### PR TITLE
update nvim/init.vim and vim/vimrc

### DIFF
--- a/nvim/init.vim
+++ b/nvim/init.vim
@@ -276,6 +276,9 @@ let g:go_highlight_types = 1
 let g:go_highlight_operators = 1
 let g:go_highlight_build_constraints = 1
 
+" disable :GoFmt when save
+let g:go_fmt_autosave = 0
+
 
 
 """""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
@@ -297,6 +300,9 @@ command! -bang -nargs=? -complete=dir Files
 
 " ,f to start files search
 nnoremap <Leader>f :Files<CR>
+
+" ,<tab> to show mapping keys in normal mode
+nmap <leader><tab> <plug>(fzf-maps-n)
 
 
 

--- a/vim/vimrc
+++ b/vim/vimrc
@@ -285,6 +285,9 @@ let g:go_highlight_types = 1
 let g:go_highlight_operators = 1
 let g:go_highlight_build_constraints = 1
 
+" disable :GoFmt when save
+let g:go_fmt_autosave = 0
+
 
 
 """""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
@@ -306,6 +309,9 @@ command! -bang -nargs=? -complete=dir Files
 
 " ,f to start files search
 nnoremap <Leader>f :Files<CR>
+
+" ,<tab> to show mapping keys in normal mode
+nmap <leader><tab> <plug>(fzf-maps-n)
 
 
 


### PR DESCRIPTION
1. Disable gofmt when save.
2. Add mapping key to show all the mapping keys in Normal mode.