### PR TITLE
setup: fix bugs caused by fixed tty

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,11 +2,7 @@ os: osx
 
 before_install:
   - brew update
-  - brew install curl
-  - brew install vim
-  - brew install neovim/neovim/neovim
   - brew install shellcheck
 
 script: |
-  make &&
   make test

--- a/setup/setup_nvim
+++ b/setup/setup_nvim
@@ -32,7 +32,7 @@ install_nvim_plug() {
 update_plugins() {
   local cmd msg
 
-  cmd="nvim +PlugInstall +qall < /dev/ttys000 > /dev/null"
+  cmd="nvim +PlugInstall +qall < $(tty) > /dev/null"
   msg="update nvim plugins [will take several minutes...]"
   do_it "${cmd}" "${msg}"
 }

--- a/setup/setup_vim
+++ b/setup/setup_vim
@@ -28,7 +28,7 @@ install_vim_plug() {
 update_plugins() {
   local cmd msg
 
-  cmd="vim +VimEnter +PlugInstall +qall < /dev/ttys000 > /dev/null"
+  cmd="vim +VimEnter +PlugInstall +qall < $(tty) > /dev/null"
   msg="update vim plugins [will take several minutes...]"
   do_it "${cmd}" "${msg}"
 }


### PR DESCRIPTION
When the script is in ubuntu or other os, the tty device is not
/dev/ttys000. Use $(tty) instead of fixed value.

Fix #15