### PR TITLE
git: add core.editor as neovim

### DIFF
--- a/git/gitconfig
+++ b/git/gitconfig
@@ -1,3 +1,5 @@
 [user]
   name  = Wei Fu
   email = fuweid89@gmail.com
+[core]
+  editor = nvim


### PR DESCRIPTION
somevm has no env EDITOR so that the git commit will use the nano editor
which I don't like. neovim is my choice.

Signed-off-by: Wei Fu <fuweid89@gmail.com>